### PR TITLE
Solved issues 20, 21, 22 and 23

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,16 +3,17 @@ import { ButtonsBar } from "./components/ButtonsBar";
 import { StagingArea } from "./components/StagingArea";
 import { loadFile } from "./utils/load";
 import { downloadFile } from "./utils/download";
-import { play } from "./utils/play";
+import { play, defaultBpm } from "./utils/play";
 
 function App() {
   const [composition, setComposition] = useState([[]]);
+  const [bpm, setBpm] = useState(defaultBpm);
   const controls = useRef({ stopPlaying: null });
   function playComposition() {
     if (controls.stopPlaying) {
       controls.stopPlaying().disconnect().dispose();
     }
-    controls.stopPlaying = play(composition);
+    controls.stopPlaying = play(composition, bpm);
   }
   function loadComposition() {
     loadFile().then(JSON.parse).then(setComposition);
@@ -52,6 +53,11 @@ function App() {
         load={loadComposition}
         play={playComposition}
         addTrack={addTrack}
+      />
+      <input
+        type="number"
+        value={bpm}
+        onChange={(e) => setBpm(e.target.value)}
       />
       <StagingArea
         composition={composition}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,12 +3,12 @@ import { ButtonsBar } from "./components/ButtonsBar";
 import { StagingArea } from "./components/StagingArea";
 import { loadFile } from "./utils/load";
 import { downloadFile } from "./utils/download";
-import { play, defaultBpm, defaultVolume } from "./utils/play";
+import { play, defaultBpm } from "./utils/play";
 
 function App() {
   const [composition, setComposition] = useState([[]]);
   const [bpm, setBpm] = useState(defaultBpm);
-  const [volume, setVolume] = useState(defaultVolume);
+  const [volume, setVolume] = useState(100);
   const controls = useRef({ commands: null });
   function playComposition() {
     if (controls.commands) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,7 +66,9 @@ function App() {
         onChange={(e) => setBpm(e.target.value)}
       />
       <input
-        type="number"
+        type="range"
+	min="0"
+	max="100"
         value={volume}
         onChange={(e) => setVolume(e.target.value)}
       />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { ButtonsBar } from "./components/ButtonsBar";
 import { StagingArea } from "./components/StagingArea";
 import { loadFile } from "./utils/load";
@@ -7,8 +7,12 @@ import { play } from "./utils/play";
 
 function App() {
   const [composition, setComposition] = useState([[]]);
+  const controls = useRef({ stopPlaying: null });
   function playComposition() {
-    play(composition);
+    if (controls.stopPlaying) {
+      controls.stopPlaying().disconnect().dispose();
+    }
+    controls.stopPlaying = play(composition);
   }
   function loadComposition() {
     loadFile().then(JSON.parse).then(setComposition);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,20 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { ButtonsBar } from "./components/ButtonsBar";
 import { StagingArea } from "./components/StagingArea";
 import { loadFile } from "./utils/load";
 import { downloadFile } from "./utils/download";
-import { play, defaultBpm } from "./utils/play";
+import { play, defaultBpm, defaultVolume } from "./utils/play";
 
 function App() {
   const [composition, setComposition] = useState([[]]);
   const [bpm, setBpm] = useState(defaultBpm);
-  const controls = useRef({ stopPlaying: null });
+  const [volume, setVolume] = useState(defaultVolume);
+  const controls = useRef({ commands: null });
   function playComposition() {
-    if (controls.stopPlaying) {
-      controls.stopPlaying().disconnect().dispose();
+    if (controls.commands) {
+      controls.commands.stopPlaying();
     }
-    controls.stopPlaying = play(composition, bpm);
+    controls.commands = play(composition, bpm, volume);
   }
   function loadComposition() {
     loadFile().then(JSON.parse).then(setComposition);
@@ -46,6 +47,11 @@ function App() {
   function addTrack() {
     setComposition((oldComposition) => [...oldComposition, []]);
   }
+  useEffect(() => {
+    if (controls.commands) {
+      controls.commands.setVolume(volume);
+    }
+  }, [volume]);
   return (
     <>
       <ButtonsBar
@@ -58,6 +64,11 @@ function App() {
         type="number"
         value={bpm}
         onChange={(e) => setBpm(e.target.value)}
+      />
+      <input
+        type="number"
+        value={volume}
+        onChange={(e) => setVolume(e.target.value)}
       />
       <StagingArea
         composition={composition}

--- a/src/components/TrackManager.jsx
+++ b/src/components/TrackManager.jsx
@@ -23,16 +23,19 @@ function TrackRow({ tone, addNote, deleteNote, notes }) {
     TEMPO_WIDTH;
   function handleMouseDown(event) {
     if (event.button == 0) {
+      const curTargetRect = event.currentTarget.getBoundingClientRect();
+      const mouseX = (event.pageX - curTargetRect.left) / TEMPO_WIDTH;
       setMouseInfo({
-        last: event.nativeEvent.offsetX / TEMPO_WIDTH,
-        now: event.nativeEvent.offsetX / TEMPO_WIDTH,
+        last: mouseX,
+        now: mouseX,
       });
     }
   }
   function handleMouseUp(event) {
-    const end = event.nativeEvent.offsetX / TEMPO_WIDTH;
     if (event.button == 0 && mouseInfo) {
-      const duration = end - mouseInfo.last;
+      const curTargetRect = event.currentTarget.getBoundingClientRect();
+      const mouseX = (event.pageX - curTargetRect.left) / TEMPO_WIDTH;
+      const duration = mouseX - mouseInfo.last;
       if (duration > 0.1) {
         addNote({ tone: tone, position: mouseInfo.last, duration: duration });
       }
@@ -41,11 +44,21 @@ function TrackRow({ tone, addNote, deleteNote, notes }) {
   }
   function handleMouseMove(event) {
     if (mouseInfo) {
-      const mouseX = event.nativeEvent.offsetX / TEMPO_WIDTH;
-      setMouseInfo((oldInfo) => ({
-        ...oldInfo,
-        now: mouseX,
-      }));
+      const curTargetRect = event.currentTarget.getBoundingClientRect();
+      const mouseX = (event.pageX - curTargetRect.left) / TEMPO_WIDTH;
+      if (
+        notes.some(
+          (note) =>
+            note.position < mouseX && mouseX < note.position + note.duration
+        )
+      ) {
+        setMouseInfo(null);
+      } else {
+        setMouseInfo((oldInfo) => ({
+          ...oldInfo,
+          now: mouseX,
+        }));
+      }
     }
   }
   function handleMouseLeave() {

--- a/src/utils/play.js
+++ b/src/utils/play.js
@@ -13,4 +13,5 @@ export function play(composition) {
       );
     }
   }
+  return () => synth.disconnect();
 }

--- a/src/utils/play.js
+++ b/src/utils/play.js
@@ -1,6 +1,7 @@
 import * as Tone from "tone";
 
-export function play(composition) {
+export const defaultBpm = 120;
+export function play(composition, bpm) {
   const synth = new Tone.PolySynth().toDestination();
   const now = Tone.now();
 
@@ -8,8 +9,8 @@ export function play(composition) {
     for (const { tone, position, duration } of track) {
       synth.triggerAttackRelease(
         tone.replaceAll("\u266D", "b"),
-        duration,
-        now + position
+        (duration * defaultBpm) / bpm,
+        now + (position * defaultBpm) / bpm
       );
     }
   }

--- a/src/utils/play.js
+++ b/src/utils/play.js
@@ -1,9 +1,11 @@
 import * as Tone from "tone";
 
 export const defaultBpm = 120;
-export function play(composition, bpm) {
+export const defaultVolume = 0;
+export function play(composition, bpm, volume) {
   const synth = new Tone.PolySynth().toDestination();
   const now = Tone.now();
+  synth.volume.value = volume;
 
   for (const track of composition) {
     for (const { tone, position, duration } of track) {
@@ -14,5 +16,8 @@ export function play(composition, bpm) {
       );
     }
   }
-  return () => synth.disconnect();
+  return {
+    stopPlaying: () => synth.disconnect().dispose(),
+    setVolume: (volume) => (synth.volume.value = volume),
+  };
 }

--- a/src/utils/play.js
+++ b/src/utils/play.js
@@ -1,23 +1,32 @@
 import * as Tone from "tone";
 
-export const defaultBpm = 120;
-export const defaultVolume = 0;
-export function play(composition, bpm, volume) {
-  const synth = new Tone.PolySynth().toDestination();
-  const now = Tone.now();
-  synth.volume.value = volume;
-
-  for (const track of composition) {
-    for (const { tone, position, duration } of track) {
-      synth.triggerAttackRelease(
-        tone.replaceAll("\u266D", "b"),
-        (duration * defaultBpm) / bpm,
-        now + (position * defaultBpm) / bpm
-      );
+const MAX_DECIBELS = 20;
+const MIN_DECIBELS = -20;
+function percentageToDecibels(percentage) {
+    if (percentage == 0) {
+        return Number.NEGATIVE_INFINITY;
     }
-  }
-  return {
-    stopPlaying: () => synth.disconnect().dispose(),
-    setVolume: (volume) => (synth.volume.value = volume),
-  };
+    return MIN_DECIBELS + ((MAX_DECIBELS - MIN_DECIBELS) * percentage / 100);
+}
+
+export const defaultBpm = 120;
+export function play(composition, bpm, volume) {
+    const synth = new Tone.PolySynth().toDestination();
+    const now = Tone.now();
+    synth.volume.value = percentageToDecibels(volume);
+
+    for (const track of composition) {
+        for (const { tone, position, duration } of track) {
+            synth.triggerAttackRelease(
+                tone.replaceAll("\u266D", "b"),
+                (duration * defaultBpm) / bpm,
+                now + (position * defaultBpm) / bpm
+            );
+        }
+    }
+    return {
+        stopPlaying: () => synth.disconnect().dispose(),
+        setVolume: (volume) =>
+            (synth.volume.value = percentageToDecibels(volume)),
+    };
 }


### PR DESCRIPTION
## Changelog
- App now stops current play before playing new one (fixes #20).
- App now prevents notes from overlapping on same row (fixes #21).
- Added option to modify BPM as a number input (implements #22).
- Added option to modify volume as a range input (implements #23).